### PR TITLE
Fix Orideco layout

### DIFF
--- a/app/orideco/layout.tsx
+++ b/app/orideco/layout.tsx
@@ -5,19 +5,36 @@ import Header from "@/components/Header";
 import { DesignElementProvider } from '@/components/DesignElementContext';
 import { EditorContextProvider } from '@/components/EditorContext';
 
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+  title: "T-shirtsEditor",
+  description: "Design your T-shirt",
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   return (
-    <div>
-      <Header/>
-      <DesignElementProvider>
-        <EditorContextProvider>
-          {children}
-        </EditorContextProvider>
-      </DesignElementProvider>
-    </div>
+    <html lang="en">
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen`}>
+        <Header />
+        <DesignElementProvider>
+          <EditorContextProvider>
+            {children}
+          </EditorContextProvider>
+        </DesignElementProvider>
+      </body>
+    </html>
   );
 }


### PR DESCRIPTION
## Summary
- reuse the html/body layout from the root
- ensure the body spans `min-h-screen` so flex centering works

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494130b22883278980031aa40ece88